### PR TITLE
Changed CS8603 Non-Nullable to Warning

### DIFF
--- a/Neolution.Debug.ruleset
+++ b/Neolution.Debug.ruleset
@@ -181,42 +181,42 @@
     <Rule Id="CS8597" Action="None" />
     <Rule Id="CS8600" Action="None" />
     <Rule Id="CS8601" Action="None" />
-    <Rule Id="CS8602" Action="None" />
+    <Rule Id="CS8602" Action="Warning" />
     <Rule Id="CS8603" Action="Warning" />
-    <Rule Id="CS8604" Action="None" />
-    <Rule Id="CS8605" Action="None" />
-    <Rule Id="CS8607" Action="None" />
-    <Rule Id="CS8608" Action="None" />
-    <Rule Id="CS8609" Action="None" />
-    <Rule Id="CS8610" Action="None" />
-    <Rule Id="CS8611" Action="None" />
-    <Rule Id="CS8612" Action="None" />
-    <Rule Id="CS8613" Action="None" />
-    <Rule Id="CS8614" Action="None" />
-    <Rule Id="CS8615" Action="None" />
-    <Rule Id="CS8616" Action="None" />
-    <Rule Id="CS8617" Action="None" />
-    <Rule Id="CS8618" Action="None" />
-    <Rule Id="CS8619" Action="None" />
-    <Rule Id="CS8620" Action="None" />
-    <Rule Id="CS8621" Action="None" />
-    <Rule Id="CS8622" Action="None" />
-    <Rule Id="CS8624" Action="None" />
-    <Rule Id="CS8625" Action="None" />
-    <Rule Id="CS8629" Action="None" />
-    <Rule Id="CS8631" Action="None" />
-    <Rule Id="CS8632" Action="None" />
-    <Rule Id="CS8633" Action="None" />
-    <Rule Id="CS8634" Action="None" />
-    <Rule Id="CS8643" Action="None" />
-    <Rule Id="CS8644" Action="None" />
-    <Rule Id="CS8645" Action="None" />
-    <Rule Id="CS8655" Action="None" />
-    <Rule Id="CS8656" Action="None" />
-    <Rule Id="CS8667" Action="None" />
+    <Rule Id="CS8604" Action="Warning" />
+    <Rule Id="CS8605" Action="Warning" />
+    <Rule Id="CS8607" Action="Warning" />
+    <Rule Id="CS8608" Action="Warning" />
+    <Rule Id="CS8609" Action="Warning" />
+    <Rule Id="CS8610" Action="Warning" />
+    <Rule Id="CS8611" Action="Warning" />
+    <Rule Id="CS8612" Action="Warning" />
+    <Rule Id="CS8613" Action="Warning" />
+    <Rule Id="CS8614" Action="Warning" />
+    <Rule Id="CS8615" Action="Warning" />
+    <Rule Id="CS8616" Action="Warning" />
+    <Rule Id="CS8617" Action="Warning" />
+    <Rule Id="CS8618" Action="Warning" />
+    <Rule Id="CS8619" Action="Warning" />
+    <Rule Id="CS8620" Action="Warning" />
+    <Rule Id="CS8621" Action="Warning" />
+    <Rule Id="CS8622" Action="Warning" />
+    <Rule Id="CS8624" Action="Warning" />
+    <Rule Id="CS8625" Action="Warning" />
+    <Rule Id="CS8629" Action="Warning" />
+    <Rule Id="CS8631" Action="Warning" />
+    <Rule Id="CS8632" Action="Warning" />
+    <Rule Id="CS8633" Action="Warning" />
+    <Rule Id="CS8634" Action="Warning" />
+    <Rule Id="CS8643" Action="Warning" />
+    <Rule Id="CS8644" Action="Warning" />
+    <Rule Id="CS8645" Action="Warning" />
+    <Rule Id="CS8655" Action="Warning" />
+    <Rule Id="CS8656" Action="Warning" />
+    <Rule Id="CS8667" Action="Warning" />
     <Rule Id="CS8669" Action="None" />
     <Rule Id="CS8670" Action="None" />
-    <Rule Id="CS8714" Action="None" />
+    <Rule Id="CS8714" Action="Warning" />
     <Rule Id="CS8762" Action="None" />
     <Rule Id="CS8763" Action="None" />
     <Rule Id="CS8764" Action="None" />

--- a/Neolution.Debug.ruleset
+++ b/Neolution.Debug.ruleset
@@ -182,7 +182,7 @@
     <Rule Id="CS8600" Action="None" />
     <Rule Id="CS8601" Action="None" />
     <Rule Id="CS8602" Action="None" />
-    <Rule Id="CS8603" Action="None" />
+    <Rule Id="CS8603" Action="Warning" />
     <Rule Id="CS8604" Action="None" />
     <Rule Id="CS8605" Action="None" />
     <Rule Id="CS8607" Action="None" />


### PR DESCRIPTION
Changed CS8603 Non-Nullable to Warning, so we can catch Non-Nullable References while developing