### PR TITLE
Rename property group variable names in targets files

### DIFF
--- a/build/Neolution.CodeAnalysis.TestsRuleset.targets
+++ b/build/Neolution.CodeAnalysis.TestsRuleset.targets
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageName>Neolution.CodeAnalysis.TestsRuleset</PackageName>
-    <PackageVersion>{{NuGetVersion}}</PackageVersion>
+    <NuGetPackageName>Neolution.CodeAnalysis.TestsRuleset</NuGetPackageName>
+    <NuGetPackageVersion>{{NuGetVersion}}</NuGetPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NuGetPackageRoot Condition="'$(UsingMicrosoftNETSdk)' == 'true' and !HasTrailingSlash('$(NuGetPackageRoot)')">$(NuGetPackageRoot.ToLower())/</NuGetPackageRoot>
-    <CodeAnalysisRuleSetLocation Condition="'$(NuGetPackageRoot)' != ''">$(NuGetPackageRoot.ToLower())$(PackageName.ToLower())/$(PackageVersion)</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' and '$(SolutionDir.ToLower())' != '*undefined*'">$(SolutionDir)packages/$(PackageName).$(PackageVersion)</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == ''">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))/packages/$(PackageName).$(PackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(NuGetPackageRoot)' != ''">$(NuGetPackageRoot.ToLower())$(NuGetPackageName.ToLower())/$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' and '$(SolutionDir.ToLower())' != '*undefined*'">$(SolutionDir)packages/$(NuGetPackageName).$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == ''">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))/packages/$(NuGetPackageName).$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
   </PropertyGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(CodeAnalysisRuleSetLocation)/Neolution.Tests.$(Configuration).ruleset</CodeAnalysisRuleSet>

--- a/build/Neolution.CodeAnalysis.targets
+++ b/build/Neolution.CodeAnalysis.targets
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageName>Neolution.CodeAnalysis</PackageName>
-    <PackageVersion>{{NuGetVersion}}</PackageVersion>
+    <NuGetPackageName>Neolution.CodeAnalysis</NuGetPackageName>
+    <NuGetPackageVersion>{{NuGetVersion}}</NuGetPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NuGetPackageRoot Condition="'$(UsingMicrosoftNETSdk)' == 'true' and !HasTrailingSlash('$(NuGetPackageRoot)')">$(NuGetPackageRoot.ToLower())/</NuGetPackageRoot>
-    <CodeAnalysisRuleSetLocation Condition="'$(NuGetPackageRoot)' != ''">$(NuGetPackageRoot.ToLower())$(PackageName.ToLower())/$(PackageVersion)</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' and '$(SolutionDir.ToLower())' != '*undefined*'">$(SolutionDir)packages/$(PackageName).$(PackageVersion)</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == ''">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))/packages/$(PackageName).$(PackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(NuGetPackageRoot)' != ''">$(NuGetPackageRoot.ToLower())$(NuGetPackageName.ToLower())/$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' and '$(SolutionDir.ToLower())' != '*undefined*'">$(SolutionDir)packages/$(NuGetPackageName).$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition="'$(CodeAnalysisRuleSetLocation)' == ''">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))/packages/$(NuGetPackageName).$(NuGetPackageVersion)</CodeAnalysisRuleSetLocation>
   </PropertyGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(CodeAnalysisRuleSetLocation)/Neolution.Release.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
`$(PackageVersion)` seems to get overridden in Azure DevOps pipeline