### PR TITLE
Empty configuration string should mean "Debug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and adheres to a project-specific [Versioning](/README.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- If build configuration is not passed explicitly, it should be like passing `Debug`
+
+### Changed
+
+- The XML documentation can be generated in all build configurations, there is no need to restrict it.
+
 ## [3.0.3] - 2023-07-20
 
 ### Fixed

--- a/build/Neolution.CodeAnalysis.TestsRuleset.props
+++ b/build/Neolution.CodeAnalysis.TestsRuleset.props
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+
+  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/build/Neolution.CodeAnalysis.props
+++ b/build/Neolution.CodeAnalysis.props
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+  <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+
+  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
and documentation files can always be generated