### PR TITLE
Never convert NU1901;NU1902;NU1903;NU1904 to Error

### DIFF
--- a/build/Neolution.CodeAnalysis.TestsRuleset.props
+++ b/build/Neolution.CodeAnalysis.TestsRuleset.props
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>    
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/build/Neolution.CodeAnalysis.props
+++ b/build/Neolution.CodeAnalysis.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">


### PR DESCRIPTION
These error codes report vulnerable packages as a warning and because we convert warnings to errors for "Release" builds, they would subsequently fail a build. Therefore, we use the `WarningsNotAsErrors` property for these error codes as recommended here: https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/